### PR TITLE
Fix close after closewrite

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -374,7 +374,7 @@ SEND_CLOSE:
 	return nil
 
 CLOSE_WRITE_CLOSE:
-	if !closeStream && s.session.config.StreamCloseTimeout > 0 {
+	if s.session.config.StreamCloseTimeout > 0 {
 		s.closeTimer = time.AfterFunc(
 			s.session.config.StreamCloseTimeout, s.closeTimeout)
 	}

--- a/stream.go
+++ b/stream.go
@@ -326,7 +326,7 @@ func (s *Stream) Close() error {
 		s.state = streamLocalClose
 		goto HANDLE_CLOSE
 	case streamCloseWrite:
-		// If we've already closed the write side, so we just need to
+		// If we've already closed the write side, we just need to
 		// close the read side and transition to streamLocalClose.
 		s.state = streamLocalClose
 		sentClose = true


### PR DESCRIPTION
This fixes Close after CloseWrite to transition to streamLocalClose and notify readers that they're closed.